### PR TITLE
DATAOPS-13977: Add tests to verify MCP server functionality

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,43 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.11, 3.12]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        version: "latest"
+
+    - name: Install dependencies
+      run: |
+        uv sync --dev
+
+    - name: Run all tests with coverage
+      run: |
+        uv run pytest tests/ --cov=src --cov-report=xml --cov-report=term-missing --cov-fail-under=85
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-umbrella
+        fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,7 @@ logs/*
 uv.lock
 src/mcp_snowflake_server/__pycache__
 **/.DS_Store
+.idea
+.roo
+.vscode
 # dist

--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,10 @@ logs/*
 .venv
 .python-version
 uv.lock
-src/mcp_snowflake_server/__pycache__
+**/__pycache__
 **/.DS_Store
 .idea
 .roo
 .vscode
+.coverage
 # dist

--- a/.roomodes
+++ b/.roomodes
@@ -1,0 +1,7 @@
+customModes:
+  - slug: mcp-test-mode
+    name: MCP Test mode
+    roleDefinition: Your role is to call the MCP tools on the snowflake MCP server. That is all you do, you do not do anything else.
+    groups:
+      - mcp
+    source: project

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,64 @@
+# Makefile for MCP Snowflake Server
+
+.PHONY: help install test coverage clean lint format check
+
+# Default target
+help:
+	@echo "Available targets:"
+	@echo "  install        Install dependencies"
+	@echo "  test           Run all tests"
+	@echo "  coverage       Run tests with coverage report"
+	@echo "  lint           Run linting checks"
+	@echo "  format         Format code"
+	@echo "  check          Run all checks (lint + test)"
+	@echo "  clean          Clean up generated files"
+
+# Install dependencies
+install:
+	uv sync --dev
+
+# Run all tests
+test:
+	python -m pytest tests/
+
+# Run tests with coverage
+coverage:
+	python -m pytest tests/ --cov=src/mcp_snowflake_server --cov-report=term-missing --cov-report=html:htmlcov
+
+# Lint code
+lint:
+	python -m pyright src/ tests/
+
+# Format code (if you add formatting tools later)
+format:
+	ruff format --diff
+
+# Run all checks
+check: lint test
+
+# Clean up generated files
+clean:
+	rm -rf htmlcov/
+	rm -rf .coverage
+	rm -rf .pytest_cache/
+	rm -rf __pycache__/
+	find . -type d -name "__pycache__" -exec rm -rf {} +
+	find . -type f -name "*.pyc" -delete
+
+# Development setup
+dev-setup: install
+	@echo "Development environment setup complete!"
+	@echo "Run 'make test' to verify everything works."
+
+# Quick test run for development
+dev-test:
+	python -m pytest tests/ -x -v --tb=short
+
+# Test with verbose output
+test-verbose:
+	python -m pytest tests/ -v -s
+
+# Generate coverage report only
+coverage-report:
+	python -m pytest tests/ --cov=src/mcp_snowflake_server --cov-report=html:htmlcov --cov-report=term
+	@echo "Coverage report generated in htmlcov/index.html"

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,55 @@
+# Testing Guide for MCP Snowflake Server
+
+## Overview
+
+This document provides a comprehensive guide to the test suite for the MCP Snowflake Server. The test suite includes unit tests, integration tests, and comprehensive coverage of all major components.
+
+## Quick Start
+
+### Install Dependencies
+```bash
+uv sync --dev
+```
+
+### Run Tests
+```bash
+# Run all tests
+make test
+
+# Run with coverage
+make coverage
+```
+
+## Test Execution Options
+
+### Basic Commands
+```bash
+# All tests
+pytest
+
+# Specific test file
+pytest tests/test_write_detector.py
+
+# Specific test method
+pytest tests/test_write_detector.py::TestSQLWriteDetector::test_analyze_select_query
+
+# With coverage
+pytest --cov=src/mcp_snowflake_server --cov-report=html
+```
+
+## Debugging Tests
+
+### Verbose Output
+```bash
+pytest -v -s --tb=long
+```
+
+### Debug Specific Test
+```bash
+pytest tests/test_write_detector.py::TestSQLWriteDetector::test_analyze_select_query -v -s
+```
+
+### Coverage Debug
+```bash
+pytest --cov=src/mcp_snowflake_server --cov-report=term-missing -v
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,14 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.uv]
-dev-dependencies = ["pyright>=1.1.389"]
+dev-dependencies = [
+    "pyright>=1.1.389",
+    "pytest>=7.4.0",
+    "pytest-asyncio>=0.21.0",
+    "pytest-cov>=4.1.0",
+    "pytest-mock>=3.11.0",
+    "coverage>=7.3.0",
+]
 
 [project.scripts]
 mcp_snowflake_server = "mcp_snowflake_server:main"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,22 @@
+[tool:pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts = 
+    -v
+    --tb=short
+    --strict-markers
+    --disable-warnings
+    --cov=src/mcp_snowflake_server
+    --cov-report=term-missing
+    --cov-report=html:htmlcov
+    --cov-fail-under=80
+markers =
+    unit: Unit tests
+    integration: Integration tests
+    slow: Slow running tests
+asyncio_mode = auto
+filterwarnings =
+    ignore::DeprecationWarning
+    ignore::PendingDeprecationWarning

--- a/src/mcp_snowflake_server/server.py
+++ b/src/mcp_snowflake_server/server.py
@@ -367,7 +367,6 @@ async def main(
     write_detector = SQLWriteDetector()
 
     tables_info = (await prefetch_tables(db, connection_args)) if prefetch else {}
-    tables_brief = data_to_yaml(tables_info) if prefetch else ""
 
     all_tools = [
         Tool(

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,80 @@
+# MCP Snowflake Server Test Suite
+
+This directory contains comprehensive unit and integration tests for the MCP Snowflake Server.
+
+## Test Structure
+
+```
+tests/
+├── __init__.py                 # Test package initialization
+├── conftest.py                 # Pytest configuration and shared fixtures
+├── test_write_detector.py      # Unit tests for SQLWriteDetector
+├── test_db_client.py           # Unit tests for SnowflakeDB client
+├── test_server_handlers.py     # Unit tests for server tool handlers
+├── test_server_integration.py  # Integration tests for main server
+├── run_tests.py                # Test runner script
+├── pytest.ini                  # Pytest configuration
+└── README.md                   # This file
+```
+
+## Test Categories
+
+### Unit Tests
+- **SQLWriteDetector Tests** (`test_write_detector.py`): Tests SQL query analysis and write operation detection
+- **SnowflakeDB Tests** (`test_db_client.py`): Tests database client functionality, connection management, and query execution
+- **Server Handler Tests** (`test_server_handlers.py`): Tests individual tool handlers and utility functions
+
+### Integration Tests
+- **Server Integration Tests** (`test_server_integration.py`): Tests complete server functionality, configuration loading, and tool integration
+
+## Running Tests
+
+### Prerequisites
+
+Install test dependencies:
+```bash
+uv sync --dev
+```
+
+### Basic Test Execution
+
+Run all tests:
+```bash
+pytest
+```
+
+Run with coverage:
+```bash
+pytest --cov=src/mcp_snowflake_server --cov-report=html
+```
+
+Run tests with additional debugging:
+```bash
+pytest -v -s --tb=long
+```
+
+Run a specific test:
+```bash
+pytest tests/test_write_detector.py::TestSQLWriteDetector::test_analyze_select_query
+```
+
+Run tests in parallel (requires pytest-xdist):
+```bash
+pytest -n auto
+```
+
+### Test Markers
+
+TODO: We should organize tests using markers:
+
+- `@pytest.mark.unit`: Unit tests
+- `@pytest.mark.integration`: Integration tests
+- `@pytest.mark.slow`: Slow-running tests
+- `@pytest.mark.asyncio`: Async tests
+
+Then, we can run specific test types:
+```bash
+pytest -m unit          # Run only unit tests
+pytest -m integration   # Run only integration tests
+pytest -m "not slow"    # Skip slow tests
+```

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for MCP Snowflake Server"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,169 @@
+"""Pytest configuration and fixtures for MCP Snowflake Server tests"""
+
+import pytest
+import asyncio
+from unittest.mock import Mock, AsyncMock
+
+from mcp import ServerCapabilities
+from mcp.server import Server
+from src.mcp_snowflake_server.db_client import SnowflakeDB
+from src.mcp_snowflake_server.write_detector import SQLWriteDetector
+
+
+@pytest.fixture
+def event_loop():
+    """Create an instance of the default event loop for the test session."""
+    loop = asyncio.get_event_loop_policy().new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture
+def mock_connection_config():
+    """Mock connection configuration for testing"""
+    return {
+        "account": "test_account",
+        "user": "test_user",
+        "password": "test_password",
+        "warehouse": "test_warehouse",
+        "database": "test_database",
+        "schema": "test_schema"
+    }
+
+
+@pytest.fixture
+def mock_snowflake_session():
+    """Mock Snowflake session for testing"""
+    session = Mock()
+    mock_df = Mock()
+    mock_df.to_dict.return_value = []
+    session.sql.return_value.to_pandas.return_value = mock_df
+    return session
+
+
+@pytest.fixture
+def mock_db_client(mock_connection_config, mock_snowflake_session):
+    """Mock SnowflakeDB client for testing"""
+    db = SnowflakeDB(mock_connection_config)
+    db.session = mock_snowflake_session
+    db.auth_time = 1000000000  # Set to avoid re-authentication
+    db.init_task = None  # No pending initialization task
+    # Mock the execute_query method to return proper async mock
+    db.execute_query = AsyncMock(return_value=([], "test-data-id"))
+    return db
+
+
+@pytest.fixture
+def write_detector():
+    """SQLWriteDetector instance for testing"""
+    return SQLWriteDetector()
+
+
+@pytest.fixture
+def mock_server():
+    """Mock MCP server for testing"""
+    server = Mock(spec=Server)
+    server.request_context = Mock()
+    server.request_context.session = Mock()
+    server.request_context.session.send_resource_updated = AsyncMock()
+    return server
+
+
+@pytest.fixture
+def sample_query_results():
+    """Sample query results for testing"""
+    return [
+        {"DATABASE_NAME": "TEST_DB1"},
+        {"DATABASE_NAME": "TEST_DB2"},
+        {"DATABASE_NAME": "EXCLUDED_DB"}
+    ]
+
+
+@pytest.fixture
+def sample_table_results():
+    """Sample table query results for testing"""
+    return [
+        {
+            "TABLE_CATALOG": "TEST_DB",
+            "TABLE_SCHEMA": "PUBLIC",
+            "TABLE_NAME": "USERS",
+            "COMMENT": "User information table"
+        },
+        {
+            "TABLE_CATALOG": "TEST_DB",
+            "TABLE_SCHEMA": "PUBLIC",
+            "TABLE_NAME": "ORDERS",
+            "COMMENT": "Order tracking table"
+        }
+    ]
+
+
+@pytest.fixture
+def sample_column_results():
+    """Sample column description results for testing"""
+    return [
+        {
+            "COLUMN_NAME": "ID",
+            "COLUMN_DEFAULT": None,
+            "IS_NULLABLE": "NO",
+            "DATA_TYPE": "NUMBER",
+            "COMMENT": "Primary key"
+        },
+        {
+            "COLUMN_NAME": "NAME",
+            "COLUMN_DEFAULT": None,
+            "IS_NULLABLE": "YES",
+            "DATA_TYPE": "VARCHAR",
+            "COMMENT": "User name"
+        }
+    ]
+
+
+@pytest.fixture
+def exclusion_config():
+    """Sample exclusion configuration for testing"""
+    return {
+        "databases": ["excluded"],
+        "schemas": ["temp"],
+        "tables": ["staging"]
+    }
+
+
+def create_mock_db_with_session(connection_config):
+    """Helper function to create a properly mocked SnowflakeDB instance"""
+    # Create the database instance
+    db = SnowflakeDB(connection_config)
+
+    # Create mock session
+    mock_session = Mock()
+    mock_df = Mock()
+    mock_df.to_dict.return_value = []
+    mock_session.sql.return_value.to_pandas.return_value = mock_df
+
+    # Set the mock session directly and prevent initialization
+    db.session = mock_session
+    db.auth_time = 1000000000  # Set to avoid re-authentication
+    db._init_database = AsyncMock()  # Mock the initialization method
+
+    return db, mock_session
+
+
+def setup_server_integration_mocks(mock_snowflake_db_class, mock_stdio_server):
+    """Helper function to set up common server integration test mocks"""
+    # Setup database mock
+    mock_db_instance = Mock()
+    mock_snowflake_db_class.return_value = mock_db_instance
+
+    # Setup stdio server mock
+    mock_read_stream = Mock()
+    mock_write_stream = Mock()
+    mock_stdio_server.return_value.__aenter__.return_value = (mock_read_stream, mock_write_stream)
+
+    # Setup server mock with capabilities
+    mock_server_instance = Mock()
+    mock_server_instance.run = AsyncMock()
+    mock_server_instance.get_capabilities.return_value = ServerCapabilities(
+        logging=None, prompts=None, resources=None, tools=None
+    )
+
+    return mock_db_instance, mock_server_instance

--- a/tests/test_db_client.py
+++ b/tests/test_db_client.py
@@ -1,0 +1,243 @@
+"""Unit tests for SnowflakeDB class"""
+import logging
+from datetime import datetime, date
+
+import pytest
+from src.mcp_snowflake_server.db_client import SnowflakeDB
+import time
+from unittest.mock import Mock, AsyncMock, patch
+
+from tests.conftest import create_mock_db_with_session
+
+
+class TestSnowflakeDB:
+    """Test cases for SnowflakeDB"""
+
+    def test_init(self, mock_connection_config):
+        """Test SnowflakeDB initialization"""
+        db = SnowflakeDB(mock_connection_config)
+
+        assert db.connection_config == mock_connection_config
+        assert db.session is None
+        assert db.insights == []
+        assert db.auth_time == 0
+        assert db.init_task is None
+
+    @pytest.mark.asyncio
+    async def test_init_database_success(self, mock_connection_config):
+        """Test successful database initialization"""
+        with patch('src.mcp_snowflake_server.db_client.Session') as mock_session_class:
+            mock_session = Mock()
+            mock_session_class.builder.configs.return_value.create.return_value = mock_session
+
+            db = SnowflakeDB(mock_connection_config)
+            await db._init_database()
+
+            assert db.session == mock_session
+            assert db.auth_time > 0
+            mock_session.sql.assert_called_once_with("USE WAREHOUSE TEST_WAREHOUSE")
+
+    @pytest.mark.asyncio
+    async def test_init_database_without_warehouse(self, mock_connection_config):
+        """Test database initialization without warehouse"""
+        config_without_warehouse = mock_connection_config.copy()
+        del config_without_warehouse['warehouse']
+
+        with patch('src.mcp_snowflake_server.db_client.Session') as mock_session_class:
+            mock_session = Mock()
+            mock_session_class.builder.configs.return_value.create.return_value = mock_session
+
+            db = SnowflakeDB(config_without_warehouse)
+            await db._init_database()
+
+            assert db.session == mock_session
+            assert db.auth_time > 0
+            mock_session.sql.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_init_database_failure(self, mock_connection_config):
+        """Test database initialization failure"""
+        with patch('src.mcp_snowflake_server.db_client.Session') as mock_session_class:
+            mock_session_class.builder.configs.return_value.create.side_effect = Exception("Connection failed")
+
+            db = SnowflakeDB(mock_connection_config)
+
+            with pytest.raises(ValueError, match="Failed to connect to Snowflake database"):
+                await db._init_database()
+
+    @patch('asyncio.get_event_loop')
+    def test_start_init_connection(self, mock_get_loop, mock_connection_config):
+        """Test starting database initialization in background"""
+        mock_loop = Mock()
+        mock_task = Mock()
+        mock_loop.create_task.return_value = mock_task
+        mock_get_loop.return_value = mock_loop
+
+        db = SnowflakeDB(mock_connection_config)
+        result = db.start_init_connection()
+
+        assert result == mock_task
+        assert db.init_task == mock_task
+        mock_loop.create_task.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_execute_query_with_init_task_pending(self, mock_db_client):
+        """Test execute_query when init_task is pending"""
+        # Create a mock task that's not done
+        mock_task = AsyncMock()
+        mock_task.done.return_value = False
+        mock_db_client.init_task = mock_task
+
+        # Set up return data
+        test_data = [{"col1": "value1"}]
+        mock_db_client.execute_query.return_value = (test_data, "test-data-id")
+
+        result_data, data_id = await mock_db_client.execute_query("SELECT * FROM test")
+
+        assert result_data == test_data
+        assert data_id == "test-data-id"
+
+    @pytest.mark.asyncio
+    async def test_execute_query_with_expired_session(self, mock_connection_config):
+        """Test execute_query when session is expired"""
+        with patch.object(SnowflakeDB, '_init_database') as mock_init:
+            db = SnowflakeDB(mock_connection_config)
+
+            # Set up expired session
+            mock_session = Mock()
+            mock_df = Mock()
+            mock_df.to_dict.return_value = [{"col1": "value1"}]
+            mock_session.sql.return_value.to_pandas.return_value = mock_df
+            db.session = mock_session
+            db.auth_time = time.time() - 2000  # Expired
+
+            result_data, data_id = await db.execute_query("SELECT * FROM test")
+
+            # Verify re-initialization was called
+            mock_init.assert_called_once()
+            assert result_data == [{"col1": "value1"}]
+            assert isinstance(data_id, str)
+
+    @pytest.mark.asyncio
+    async def test_execute_query_success(self, mock_db_client):
+        """Test successful query execution"""
+        # Setup mock return data
+        test_data = [
+            {"id": 1, "name": "John"},
+            {"id": 2, "name": "Jane"}
+        ]
+        mock_db_client.execute_query.return_value = (test_data, "test-data-id")
+
+        result_data, data_id = await mock_db_client.execute_query("SELECT * FROM users")
+
+        assert result_data == test_data
+        assert data_id == "test-data-id"
+        mock_db_client.execute_query.assert_called_once_with("SELECT * FROM users")
+
+    @pytest.mark.asyncio
+    async def test_execute_query_failure(self, mock_db_client):
+        """Test query execution failure"""
+        mock_db_client.execute_query.side_effect = Exception("SQL execution failed")
+
+        with pytest.raises(Exception, match="SQL execution failed"):
+            await mock_db_client.execute_query("INVALID SQL")
+
+    @pytest.mark.asyncio
+    async def test_execute_query_with_complex_data_types(self, mock_db_client):
+        """Test query execution with complex data types"""
+        # Setup mock return data with various data types
+        test_data = [
+            {
+                "id": 1,
+                "name": "John",
+                "created_date": date(2023, 1, 1),
+                "updated_timestamp": datetime(2023, 1, 1, 12, 0, 0),
+                "amount": 123.45,
+                "is_active": True,
+                "metadata": None
+            }
+        ]
+        mock_db_client.execute_query.return_value = (test_data, "test-data-id")
+
+        result_data, data_id = await mock_db_client.execute_query("SELECT * FROM complex_table")
+
+        assert result_data == test_data
+        assert data_id == "test-data-id"
+
+    def test_add_insight(self, mock_db_client):
+        """Test adding insights to the collection"""
+        assert len(mock_db_client.insights) == 0
+
+        mock_db_client.add_insight("First insight")
+        assert len(mock_db_client.insights) == 1
+        assert mock_db_client.insights[0] == "First insight"
+
+        mock_db_client.add_insight("Second insight")
+        assert len(mock_db_client.insights) == 2
+        assert mock_db_client.insights[1] == "Second insight"
+
+    def test_get_memo_empty(self, mock_db_client):
+        """Test getting memo when no insights exist"""
+        memo = mock_db_client.get_memo()
+        assert memo == "No data insights have been discovered yet."
+
+    def test_get_memo_single_insight(self, mock_db_client):
+        """Test getting memo with single insight"""
+        mock_db_client.add_insight("Users table has 1000 records")
+        memo = mock_db_client.get_memo()
+
+        assert "📊 Data Intelligence Memo 📊" in memo
+        assert "Key Insights Discovered:" in memo
+        assert "- Users table has 1000 records" in memo
+        assert "Summary:" not in memo  # No summary for single insight
+
+    def test_get_memo_multiple_insights(self, mock_db_client):
+        """Test getting memo with multiple insights"""
+        mock_db_client.add_insight("Users table has 1000 records")
+        mock_db_client.add_insight("Orders table shows 50% growth")
+        mock_db_client.add_insight("Revenue increased by 25%")
+
+        memo = mock_db_client.get_memo()
+
+        assert "📊 Data Intelligence Memo 📊" in memo
+        assert "Key Insights Discovered:" in memo
+        assert "- Users table has 1000 records" in memo
+        assert "- Orders table shows 50% growth" in memo
+        assert "- Revenue increased by 25%" in memo
+        assert "Summary:" in memo
+        assert "3 key data insights" in memo
+
+    @pytest.mark.asyncio
+    async def test_execute_query_logging(self, mock_connection_config, caplog):
+        """Test that query execution logs appropriately"""
+        db, mock_session = create_mock_db_with_session(mock_connection_config)
+        mock_session.sql.return_value.to_pandas.return_value.to_dict.return_value = [{"col1": "value1"}]
+
+        with caplog.at_level(logging.DEBUG):
+            await db.execute_query("SELECT * FROM test")
+
+        # Check that debug log was created
+        assert any("Executing query: SELECT * FROM test" in record.message for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_execute_query_error_logging(self, mock_connection_config):
+        """Test that query execution errors are logged"""
+        db, mock_session = create_mock_db_with_session(mock_connection_config)
+        mock_session.sql.side_effect = Exception("Database connection lost")
+
+        # Test that the exception is raised (the logging is tested implicitly)
+        with pytest.raises(Exception, match="Database connection lost"):
+            await db.execute_query("SELECT * FROM test")
+
+    @pytest.mark.asyncio
+    async def test_execute_query_uuid_generation(self, mock_connection_config):
+        """Test that each query execution generates a unique data_id"""
+        db, mock_session = create_mock_db_with_session(mock_connection_config)
+        mock_session.sql.return_value.to_pandas.return_value.to_dict.return_value = [{"col1": "value1"}]
+
+        _, data_id1 = await db.execute_query("SELECT * FROM test1")
+        _, data_id2 = await db.execute_query("SELECT * FROM test2")
+
+        assert data_id1 != data_id2
+        assert len(data_id1) == 36  # UUID4 length
+        assert len(data_id2) == 36  # UUID4 length

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -1,0 +1,373 @@
+"""Unit tests for server tool handlers"""
+
+from datetime import date, datetime
+import pytest
+import json
+import mcp.types as types
+from pydantic import AnyUrl
+
+from src.mcp_snowflake_server.server import (
+    handle_list_databases,
+    handle_list_schemas,
+    handle_list_tables,
+    handle_describe_table,
+    handle_read_query,
+    handle_append_insight,
+    handle_write_query,
+    handle_create_table,
+    data_to_yaml,
+    data_json_serializer,
+    handle_tool_errors
+)
+
+
+class TestServerHandlers:
+    """Test cases for server tool handlers"""
+
+    @pytest.mark.asyncio
+    async def test_handle_list_databases_success(self, mock_db_client, sample_query_results):
+        """Test successful database listing"""
+        mock_db_client.execute_query.return_value = (sample_query_results, "test-data-id")
+
+        result = await handle_list_databases({}, mock_db_client)
+
+        assert len(result) == 2
+        assert isinstance(result[0], types.TextContent)
+        assert isinstance(result[1], types.EmbeddedResource)
+
+        # Check YAML content
+        yaml_content = result[0].text
+        assert "TEST_DB1" in yaml_content
+        assert "TEST_DB2" in yaml_content
+
+        # Check embedded resource
+        resource = result[1].resource
+        assert str(resource.uri) == "data://test-data-id"
+        assert resource.mimeType == "application/json"
+
+    @pytest.mark.asyncio
+    async def test_handle_list_databases_with_exclusions(self, mock_db_client, sample_query_results, exclusion_config):
+        """Test database listing with exclusion patterns"""
+        mock_db_client.execute_query.return_value = (sample_query_results, "test-data-id")
+
+        result = await handle_list_databases({}, mock_db_client, exclusion_config=exclusion_config)
+
+        # Parse the JSON from embedded resource to check filtering
+        resource_content = json.loads(result[1].resource.text)
+        database_names = [item["DATABASE_NAME"] for item in resource_content["data"]]
+
+        # Should exclude "EXCLUDED_DB" based on exclusion pattern
+        assert "TEST_DB1" in database_names
+        assert "TEST_DB2" in database_names
+        assert "EXCLUDED_DB" not in database_names
+
+    @pytest.mark.asyncio
+    async def test_handle_list_schemas_success(self, mock_db_client, sample_query_results):
+        """Test successful schema listing"""
+        mock_db_client.execute_query.return_value = (sample_query_results, "test-data-id")
+        arguments = {"database": "TEST_DB"}
+
+        result = await handle_list_schemas(arguments, mock_db_client)
+
+        assert len(result) == 2
+        assert isinstance(result[0], types.TextContent)
+        assert isinstance(result[1], types.EmbeddedResource)
+
+        # Check that database name is included in output
+        resource_content = json.loads(result[1].resource.text)
+        assert resource_content["database"] == "TEST_DB"
+
+    @pytest.mark.asyncio
+    async def test_handle_list_schemas_missing_database(self, mock_db_client):
+        """Test schema listing with missing database parameter"""
+        with pytest.raises(ValueError, match="Missing required 'database' parameter"):
+            await handle_list_schemas({}, mock_db_client)
+
+        with pytest.raises(ValueError, match="Missing required 'database' parameter"):
+            await handle_list_schemas(None, mock_db_client)
+
+    @pytest.mark.asyncio
+    async def test_handle_list_tables_success(self, mock_db_client, sample_table_results):
+        """Test successful table listing"""
+        mock_db_client.execute_query.return_value = (sample_table_results, "test-data-id")
+        arguments = {"database": "TEST_DB", "schema": "PUBLIC"}
+
+        result = await handle_list_tables(arguments, mock_db_client)
+
+        assert len(result) == 2
+        assert isinstance(result[0], types.TextContent)
+        assert isinstance(result[1], types.EmbeddedResource)
+
+        # Check that database and schema are included in output
+        resource_content = json.loads(result[1].resource.text)
+        assert resource_content["database"] == "TEST_DB"
+        assert resource_content["schema"] == "PUBLIC"
+
+    @pytest.mark.asyncio
+    async def test_handle_list_tables_missing_parameters(self, mock_db_client):
+        """Test table listing with missing parameters"""
+        with pytest.raises(ValueError, match="Missing required 'database' and 'schema' parameters"):
+            await handle_list_tables({}, mock_db_client)
+
+        with pytest.raises(ValueError, match="Missing required 'database' and 'schema' parameters"):
+            await handle_list_tables({"database": "TEST_DB"}, mock_db_client)
+
+    @pytest.mark.asyncio
+    async def test_handle_describe_table_success(self, mock_db_client, sample_column_results):
+        """Test successful table description"""
+        mock_db_client.execute_query.return_value = (sample_column_results, "test-data-id")
+        arguments = {"table_name": "TEST_DB.PUBLIC.USERS"}
+
+        result = await handle_describe_table(arguments, mock_db_client)
+
+        assert len(result) == 2
+        assert isinstance(result[0], types.TextContent)
+        assert isinstance(result[1], types.EmbeddedResource)
+
+        # Check that table components are parsed correctly
+        resource_content = json.loads(result[1].resource.text)
+        assert resource_content["database"] == "TEST_DB"
+        assert resource_content["schema"] == "PUBLIC"
+        assert resource_content["table"] == "USERS"
+
+    @pytest.mark.asyncio
+    async def test_handle_describe_table_invalid_format(self, mock_db_client):
+        """Test table description with invalid table name format"""
+        with pytest.raises(ValueError, match="Missing table_name argument"):
+            await handle_describe_table({}, mock_db_client)
+
+        with pytest.raises(ValueError, match="Table name must be fully qualified"):
+            await handle_describe_table({"table_name": "invalid_format"}, mock_db_client)
+
+    @pytest.mark.asyncio
+    async def test_handle_read_query_success(self, mock_db_client, write_detector):
+        """Test successful read query execution"""
+        query_results = [{"id": 1, "name": "John"}, {"id": 2, "name": "Jane"}]
+        mock_db_client.execute_query.return_value = (query_results, "test-data-id")
+        arguments = {"query": "SELECT * FROM users"}
+
+        result = await handle_read_query(arguments, mock_db_client, write_detector)
+
+        assert len(result) == 2
+        assert isinstance(result[0], types.TextContent)
+        assert isinstance(result[1], types.EmbeddedResource)
+
+    @pytest.mark.asyncio
+    async def test_handle_read_query_with_write_operation(self, mock_db_client, write_detector):
+        """Test read query handler rejecting write operations"""
+        arguments = {"query": "INSERT INTO users VALUES (1, 'John')"}
+
+        with pytest.raises(ValueError, match="Calls to read_query should not contain write operations"):
+            await handle_read_query(arguments, mock_db_client, write_detector)
+
+    @pytest.mark.asyncio
+    async def test_handle_read_query_missing_query(self, mock_db_client, write_detector):
+        """Test read query handler with missing query parameter"""
+        with pytest.raises(ValueError, match="Missing query argument"):
+            await handle_read_query({}, mock_db_client, write_detector)
+
+    @pytest.mark.asyncio
+    async def test_handle_append_insight_success(self, mock_db_client, mock_server):
+        """Test successful insight appending"""
+        arguments = {"insight": "Users table has grown by 20%"}
+
+        result = await handle_append_insight(arguments, mock_db_client, None, None, mock_server)
+
+        assert len(result) == 1
+        assert isinstance(result[0], types.TextContent)
+        assert result[0].text == "Insight added to memo"
+
+        # Verify insight was added to database
+        assert "Users table has grown by 20%" in mock_db_client.insights
+
+        # Verify resource update notification was sent
+        mock_server.request_context.session.send_resource_updated.assert_called_once_with(
+            AnyUrl("memo://insights")
+        )
+
+    @pytest.mark.asyncio
+    async def test_handle_append_insight_missing_insight(self, mock_db_client, mock_server):
+        """Test insight appending with missing insight parameter"""
+        with pytest.raises(ValueError, match="Missing insight argument"):
+            await handle_append_insight({}, mock_db_client, None, None, mock_server)
+
+    @pytest.mark.asyncio
+    async def test_handle_write_query_success(self, mock_db_client):
+        """Test successful write query execution"""
+        mock_db_client.execute_query.return_value = ("Query executed successfully", "test-data-id")
+        arguments = {"query": "INSERT INTO users VALUES (1, 'John')"}
+        allow_write = True
+
+        result = await handle_write_query(arguments, mock_db_client, None, allow_write, None)
+
+        assert len(result) == 1
+        assert isinstance(result[0], types.TextContent)
+        assert "Query executed successfully" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_handle_write_query_not_allowed(self, mock_db_client):
+        """Test write query when write operations are not allowed"""
+        arguments = {"query": "INSERT INTO users VALUES (1, 'John')"}
+        allow_write = False
+
+        with pytest.raises(ValueError, match="Write operations are not allowed"):
+            await handle_write_query(arguments, mock_db_client, None, allow_write, None)
+
+    @pytest.mark.asyncio
+    async def test_handle_write_query_select_not_allowed(self, mock_db_client):
+        """Test write query handler rejecting SELECT queries"""
+        arguments = {"query": "SELECT * FROM users"}
+        allow_write = True
+
+        with pytest.raises(ValueError, match="SELECT queries are not allowed for write_query"):
+            await handle_write_query(arguments, mock_db_client, None, allow_write, None)
+
+    @pytest.mark.asyncio
+    async def test_handle_create_table_success(self, mock_db_client):
+        """Test successful table creation"""
+        mock_db_client.execute_query.return_value = ("Table created", "test-data-id")
+        arguments = {"query": "CREATE TABLE test_table (id INT, name VARCHAR(100))"}
+        allow_write = True
+
+        result = await handle_create_table(arguments, mock_db_client, None, allow_write, None)
+
+        assert len(result) == 1
+        assert isinstance(result[0], types.TextContent)
+        assert "Table created successfully" in result[0].text
+        assert "test-data-id" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_handle_create_table_not_allowed(self, mock_db_client):
+        """Test table creation when write operations are not allowed"""
+        arguments = {"query": "CREATE TABLE test_table (id INT)"}
+        allow_write = False
+
+        with pytest.raises(ValueError, match="Write operations are not allowed"):
+            await handle_create_table(arguments, mock_db_client, None, allow_write, None)
+
+    @pytest.mark.asyncio
+    async def test_handle_create_table_invalid_query(self, mock_db_client):
+        """Test table creation with invalid query"""
+        arguments = {"query": "DROP TABLE test_table"}
+        allow_write = True
+
+        with pytest.raises(ValueError, match="Only CREATE TABLE statements are allowed"):
+            await handle_create_table(arguments, mock_db_client, None, allow_write, None)
+
+
+class TestUtilityFunctions:
+    """Test cases for utility functions"""
+
+    def test_data_to_yaml(self):
+        """Test YAML conversion function"""
+        data = {"key": "value", "number": 42, "list": [1, 2, 3]}
+        yaml_output = data_to_yaml(data)
+
+        assert "key: value" in yaml_output
+        assert "number: 42" in yaml_output
+        assert "list:" in yaml_output
+
+    def test_data_json_serializer_with_date(self):
+        """Test JSON serializer with date objects"""
+        test_date = date(2023, 1, 1)
+        test_datetime = datetime(2023, 1, 1, 12, 0, 0)
+
+        assert data_json_serializer(test_date) == "2023-01-01"
+        assert data_json_serializer(test_datetime) == "2023-01-01T12:00:00"
+        assert data_json_serializer("regular_string") == "regular_string"
+        assert data_json_serializer(42) == 42
+
+    @pytest.mark.asyncio
+    async def test_handle_tool_errors_decorator(self):
+        """Test the error handling decorator"""
+
+        @handle_tool_errors
+        async def failing_function():
+            raise Exception("Test error")
+
+        @handle_tool_errors
+        async def successful_function():
+            return [types.TextContent(type="text", text="Success")]
+
+        # Test error case
+        error_result = await failing_function()
+        assert len(error_result) == 1
+        assert isinstance(error_result[0], types.TextContent)
+        assert "Error: Test error" in error_result[0].text
+
+        # Test success case
+        success_result = await successful_function()
+        assert len(success_result) == 1
+        assert success_result[0].text == "Success"
+
+
+class TestExclusionFiltering:
+    """Test cases for exclusion pattern filtering"""
+
+    @pytest.mark.asyncio
+    async def test_database_exclusion_filtering(self, mock_db_client):
+        """Test database exclusion filtering"""
+        sample_data = [
+            {"DATABASE_NAME": "PROD_DB"},
+            {"DATABASE_NAME": "TEST_DB"},
+            {"DATABASE_NAME": "TEMP_DATABASE"},
+            {"DATABASE_NAME": "STAGING_DB"}
+        ]
+        mock_db_client.execute_query.return_value = (sample_data, "test-id")
+
+        exclusion_config = {"databases": ["temp", "staging"]}
+
+        result = await handle_list_databases({}, mock_db_client, exclusion_config=exclusion_config)
+        resource_content = json.loads(result[1].resource.text)
+        database_names = [item["DATABASE_NAME"] for item in resource_content["data"]]
+
+        assert "PROD_DB" in database_names
+        assert "TEST_DB" in database_names
+        assert "TEMP_DATABASE" not in database_names  # Contains "temp"
+        assert "STAGING_DB" not in database_names  # Contains "staging"
+
+    @pytest.mark.asyncio
+    async def test_schema_exclusion_filtering(self, mock_db_client):
+        """Test schema exclusion filtering"""
+        sample_data = [
+            {"SCHEMA_NAME": "PUBLIC"},
+            {"SCHEMA_NAME": "PRIVATE"},
+            {"SCHEMA_NAME": "TEMP_SCHEMA"},
+            {"SCHEMA_NAME": "INFORMATION_SCHEMA"}
+        ]
+        mock_db_client.execute_query.return_value = (sample_data, "test-id")
+
+        exclusion_config = {"schemas": ["temp", "information"]}
+        arguments = {"database": "TEST_DB"}
+
+        result = await handle_list_schemas(arguments, mock_db_client, exclusion_config=exclusion_config)
+        resource_content = json.loads(result[1].resource.text)
+        schema_names = [item["SCHEMA_NAME"] for item in resource_content["data"]]
+
+        assert "PUBLIC" in schema_names
+        assert "PRIVATE" in schema_names
+        assert "TEMP_SCHEMA" not in schema_names  # Contains "temp"
+        assert "INFORMATION_SCHEMA" not in schema_names  # Contains "information"
+
+    @pytest.mark.asyncio
+    async def test_table_exclusion_filtering(self, mock_db_client):
+        """Test table exclusion filtering"""
+        sample_data = [
+            {"TABLE_NAME": "USERS", "TABLE_CATALOG": "DB", "TABLE_SCHEMA": "PUBLIC", "COMMENT": ""},
+            {"TABLE_NAME": "ORDERS", "TABLE_CATALOG": "DB", "TABLE_SCHEMA": "PUBLIC", "COMMENT": ""},
+            {"TABLE_NAME": "TEMP_TABLE", "TABLE_CATALOG": "DB", "TABLE_SCHEMA": "PUBLIC", "COMMENT": ""},
+            {"TABLE_NAME": "STAGING_DATA", "TABLE_CATALOG": "DB", "TABLE_SCHEMA": "PUBLIC", "COMMENT": ""}
+        ]
+        mock_db_client.execute_query.return_value = (sample_data, "test-id")
+
+        exclusion_config = {"tables": ["temp", "staging"]}
+        arguments = {"database": "TEST_DB", "schema": "PUBLIC"}
+
+        result = await handle_list_tables(arguments, mock_db_client, exclusion_config=exclusion_config)
+        resource_content = json.loads(result[1].resource.text)
+        table_names = [item["TABLE_NAME"] for item in resource_content["data"]]
+
+        assert "USERS" in table_names
+        assert "ORDERS" in table_names
+        assert "TEMP_TABLE" not in table_names  # Contains "temp"
+        assert "STAGING_DATA" not in table_names  # Contains "staging"

--- a/tests/test_server_integration.py
+++ b/tests/test_server_integration.py
@@ -1,0 +1,384 @@
+"""Integration tests for the main server functionality"""
+
+import pytest
+import json
+import logging
+from unittest.mock import mock_open, Mock, AsyncMock, patch
+
+import mcp.types as types
+from pydantic import AnyUrl
+from src.mcp_snowflake_server.server import main, prefetch_tables
+
+from tests.conftest import setup_server_integration_mocks, mock_connection_config
+
+
+class TestServerIntegration:
+    """Integration test cases for the main server functionality"""
+
+    @pytest.mark.asyncio
+    async def test_prefetch_tables_success(self, mock_db_client):
+        """Test successful table prefetching"""
+        # Mock table results
+        table_results = [
+            {"TABLE_NAME": "USERS", "COMMENT": "User data"},
+            {"TABLE_NAME": "ORDERS", "COMMENT": "Order data"}
+        ]
+
+        # Mock column results
+        column_results = [
+            {"TABLE_NAME": "USERS", "COLUMN_NAME": "ID", "DATA_TYPE": "NUMBER", "COMMENT": "Primary key"},
+            {"TABLE_NAME": "USERS", "COLUMN_NAME": "NAME", "DATA_TYPE": "VARCHAR", "COMMENT": "User name"},
+            {"TABLE_NAME": "ORDERS", "COLUMN_NAME": "ID", "DATA_TYPE": "NUMBER", "COMMENT": "Order ID"},
+            {"TABLE_NAME": "ORDERS", "COLUMN_NAME": "USER_ID", "DATA_TYPE": "NUMBER", "COMMENT": "Foreign key"}
+        ]
+
+        # Setup mock to return different results for different queries
+        def mock_execute_query(query):
+            if "information_schema.tables" in query.lower():
+                return table_results, "table-data-id"
+            elif "information_schema.columns" in query.lower():
+                return column_results, "column-data-id"
+            return [], "default-id"
+
+        mock_db_client.execute_query.side_effect = mock_execute_query
+
+        credentials = {"database": "TEST_DB", "schema": "PUBLIC"}
+        result = await prefetch_tables(mock_db_client, credentials)
+
+        expected = {"TABLE_NAME": "USERS", "COMMENT": "User data",
+                    "COLUMNS": {'ID': {'COLUMN_NAME': 'ID', 'COMMENT': 'Primary key', 'DATA_TYPE': 'NUMBER'},
+                                'NAME': {'COLUMN_NAME': 'NAME', 'COMMENT': 'User name', 'DATA_TYPE': 'VARCHAR'}}}
+        # Verify users table
+        assert result["USERS"] == expected
+
+    @pytest.mark.asyncio
+    async def test_prefetch_tables_error(self, mock_db_client, caplog):
+        """Test table prefetching with database error"""
+        mock_db_client.execute_query.side_effect = Exception("Database connection failed")
+
+        credentials = {"database": "TEST_DB", "schema": "PUBLIC"}
+
+        with caplog.at_level(logging.ERROR):
+            result = await prefetch_tables(mock_db_client, credentials)
+
+        # Should return error message as string
+        assert isinstance(result, str)
+        assert "Error prefetching table descriptions" in result
+        assert "Database connection failed" in result
+
+        # Check error was logged
+        assert any("Error prefetching table descriptions" in record.message for record in caplog.records)
+
+    @patch('src.mcp_snowflake_server.server.mcp.server.stdio.stdio_server')
+    @patch('src.mcp_snowflake_server.server.SnowflakeDB')
+    @pytest.mark.asyncio
+    async def test_main_function_basic_setup(self, mock_snowflake_db_class, mock_stdio_server, mock_connection_config):
+        """Test main function basic setup and configuration"""
+        mock_db_instance, mock_server_instance = setup_server_integration_mocks(
+            mock_snowflake_db_class, mock_stdio_server
+        )
+
+        with patch('src.mcp_snowflake_server.server.Server') as mock_server_class:
+            mock_server_class.return_value = mock_server_instance
+
+            # Call main function
+            await main(
+                allow_write=False,
+                connection_args=mock_connection_config,
+                log_level="DEBUG",
+                exclude_tools=["write_query"],
+                prefetch=False
+            )
+
+            # Verify database initialization
+            mock_snowflake_db_class.assert_called_once_with(mock_connection_config)
+            mock_db_instance.start_init_connection.assert_called_once()
+
+            # Verify server was created and run
+            mock_server_class.assert_called_once_with("snowflake-manager")
+            mock_server_instance.run.assert_called_once()
+
+    @patch('src.mcp_snowflake_server.server.mcp.server.stdio.stdio_server')
+    @patch('src.mcp_snowflake_server.server.SnowflakeDB')
+    @pytest.mark.asyncio
+    async def test_main_function_with_prefetch(self, mock_snowflake_db_class, mock_stdio_server, mock_connection_config):
+        """Test main function with table prefetching enabled"""
+        mock_db_instance, mock_server_instance = setup_server_integration_mocks(
+            mock_snowflake_db_class, mock_stdio_server
+        )
+
+        # Mock prefetch_tables function
+        with patch('src.mcp_snowflake_server.server.prefetch_tables') as mock_prefetch:
+            mock_prefetch.return_value = {"USERS": {"TABLE_NAME": "USERS", "COLUMNS": {}}}
+
+            with patch('src.mcp_snowflake_server.server.Server') as mock_server_class:
+                mock_server_class.return_value = mock_server_instance
+
+                await main(
+                    allow_write=True,
+                    connection_args=mock_connection_config,
+                    prefetch=True
+                )
+
+                # Verify prefetch was called
+                mock_prefetch.assert_called_once_with(mock_db_instance, mock_connection_config)
+
+    @patch('src.mcp_snowflake_server.server.mcp.server.stdio.stdio_server')
+    @patch('src.mcp_snowflake_server.server.SnowflakeDB')
+    @pytest.mark.asyncio
+    async def test_main_function_with_config_file(self, mock_snowflake_db_class, mock_stdio_server):
+        """Test main function with configuration file loading"""
+        mock_db_instance, mock_server_instance = setup_server_integration_mocks(
+            mock_snowflake_db_class, mock_stdio_server
+        )
+
+        # Mock config file content
+        config_content = {
+            "exclude_patterns": {
+                "databases": ["temp"],
+                "schemas": ["staging"],
+                "tables": ["test"]
+            }
+        }
+
+        with patch('builtins.open', mock_open_with_content(json.dumps(config_content))):
+            with patch('src.mcp_snowflake_server.server.Server') as mock_server_class:
+                mock_server_class.return_value = mock_server_instance
+
+                connection_args = {"database": "test_db"}
+
+                await main(
+                    connection_args=connection_args,
+                    config_file="test_config.json"
+                )
+
+                # Verify server was created (config loading is internal)
+                mock_server_class.assert_called_once_with("snowflake-manager")
+
+    @patch('src.mcp_snowflake_server.server.mcp.server.stdio.stdio_server')
+    @patch('src.mcp_snowflake_server.server.SnowflakeDB')
+    @pytest.mark.asyncio
+    async def test_main_function_stdio_error(self, mock_snowflake_db_class, mock_stdio_server):
+        """Test main function handling stdio server errors"""
+        # Setup mocks
+        mock_db_instance = Mock()
+        mock_snowflake_db_class.return_value = mock_db_instance
+
+        # Make stdio_server raise an exception
+        mock_stdio_server.side_effect = Exception("Failed to start stdio server")
+
+        connection_args = {"database": "test_db"}
+
+        with pytest.raises(Exception, match="Failed to start stdio server"):
+            await main(connection_args=connection_args)
+
+
+    @patch('src.mcp_snowflake_server.server.mcp.server.stdio.stdio_server')
+    @patch('src.mcp_snowflake_server.server.SnowflakeDB')
+    @pytest.mark.asyncio
+    async def test_main_function_tool_filtering(self, mock_snowflake_db_class, mock_stdio_server):
+        """Test main function tool filtering based on allow_write and exclude_tools"""
+        mock_db_instance, mock_server_instance = setup_server_integration_mocks(
+            mock_snowflake_db_class, mock_stdio_server
+        )
+
+        # Capture the list_tools handler
+        list_tools_handler = None
+
+        def capture_list_tools():
+            def decorator(func):
+                nonlocal list_tools_handler
+                list_tools_handler = func
+                return func
+
+            return decorator
+
+        mock_server_instance.list_tools = capture_list_tools
+
+        with patch('src.mcp_snowflake_server.server.Server') as mock_server_class:
+            mock_server_class.return_value = mock_server_instance
+
+            connection_args = {"database": "test_db"}
+
+            await main(
+                allow_write=False,  # Should exclude write tools
+                connection_args=connection_args,
+                exclude_tools=["describe_table"]  # Should exclude this tool
+            )
+
+            # Test the list_tools handler
+            tool_names = {}
+            if list_tools_handler:
+                tools = await list_tools_handler()
+                tool_names = {tool.name for tool in tools}
+
+            # Should include read-only tools
+            assert tool_names == {'list_databases', 'list_schemas', 'list_tables', 'read_query', 'append_insight'}
+
+
+class TestServerResourceHandlers:
+    """Test cases for server resource handlers"""
+
+    @patch('src.mcp_snowflake_server.server.mcp.server.stdio.stdio_server')
+    @patch('src.mcp_snowflake_server.server.SnowflakeDB')
+    @pytest.mark.asyncio
+    async def test_resource_handlers_setup(self, mock_snowflake_db_class, mock_stdio_server):
+        """Test that resource handlers are properly set up"""
+        mock_db_instance, mock_server_instance = setup_server_integration_mocks(
+            mock_snowflake_db_class, mock_stdio_server
+        )
+        mock_db_instance.get_memo.return_value = "Test memo content"
+
+        # Capture resource handlers
+        list_resources_handler = None
+        read_resource_handler = None
+
+        def capture_list_resources():
+            def decorator(func):
+                nonlocal list_resources_handler
+                list_resources_handler = func
+                return func
+
+            return decorator
+
+        def capture_read_resource():
+            def decorator(func):
+                nonlocal read_resource_handler
+                read_resource_handler = func
+                return func
+
+            return decorator
+
+        mock_server_instance.list_resources = capture_list_resources
+        mock_server_instance.read_resource = capture_read_resource
+
+        with patch('src.mcp_snowflake_server.server.Server') as mock_server_class:
+            mock_server_class.return_value = mock_server_instance
+
+            connection_args = {"database": "test_db"}
+
+            await main(connection_args=connection_args, prefetch=False)
+
+            # Test list_resources handler
+            if list_resources_handler:
+                resources = await list_resources_handler()
+                assert len(resources) >= 1
+
+                # Should include memo resource
+                memo_resource = next((r for r in resources if str(r.uri) == "memo://insights"), None)
+                assert memo_resource is not None
+                assert memo_resource.name == "Data Insights Memo"
+                assert memo_resource.mimeType == "text/plain"
+
+            # Test read_resource handler
+            if read_resource_handler:
+                # Test memo resource
+                memo_content = await read_resource_handler(AnyUrl("memo://insights"))
+                assert memo_content == "Test memo content"
+
+                # Test unknown resource
+                with pytest.raises(ValueError, match="Unknown resource"):
+                    await read_resource_handler(AnyUrl("unknown://resource"))
+
+
+def mock_open_with_content(content):
+    """Helper function to create a mock open that returns specific content"""
+    return mock_open(read_data=content)
+
+
+class TestServerToolHandlerIntegration:
+    """Integration tests for server tool handler registration"""
+
+    @patch('src.mcp_snowflake_server.server.mcp.server.stdio.stdio_server')
+    @patch('src.mcp_snowflake_server.server.SnowflakeDB')
+    @pytest.mark.asyncio
+    async def test_call_tool_handler_integration(self, mock_snowflake_db_class, mock_stdio_server):
+        """Test that call_tool handler is properly integrated"""
+        mock_db_instance, mock_server_instance = setup_server_integration_mocks(
+            mock_snowflake_db_class, mock_stdio_server
+        )
+        mock_db_instance.execute_query = AsyncMock(return_value=([{"DATABASE_NAME": "TEST_DB"}], "test-id"))
+
+        # Capture call_tool handler
+        call_tool_handler = None
+
+        def capture_call_tool():
+            def decorator(func):
+                nonlocal call_tool_handler
+                call_tool_handler = func
+                return func
+
+            return decorator
+
+        mock_server_instance.call_tool = capture_call_tool
+
+        with patch('src.mcp_snowflake_server.server.Server') as mock_server_class:
+            mock_server_class.return_value = mock_server_instance
+
+            connection_args = {"database": "test_db"}
+
+            await main(connection_args=connection_args)
+
+            # Test call_tool handler
+            if call_tool_handler:
+                # Test valid tool call
+                result = await call_tool_handler("list_databases", {})
+                assert len(result) == 2  # YAML content + embedded resource
+                assert isinstance(result[0], types.TextContent)
+                assert isinstance(result[1], types.EmbeddedResource)
+
+                # Test unknown tool - the error decorator catches exceptions and returns error text
+                result = await call_tool_handler("unknown_tool", {})
+                assert len(result) == 1
+                assert isinstance(result[0], types.TextContent)
+                assert "Error: Unknown tool: unknown_tool" in result[0].text
+
+    @patch('src.mcp_snowflake_server.server.mcp.server.stdio.stdio_server')
+    @patch('src.mcp_snowflake_server.server.SnowflakeDB')
+    @pytest.mark.asyncio
+    async def test_exclusion_config_integration(self, mock_snowflake_db_class, mock_stdio_server):
+        """Test that exclusion configuration is properly integrated"""
+        mock_db_instance, mock_server_instance = setup_server_integration_mocks(
+            mock_snowflake_db_class, mock_stdio_server
+        )
+        mock_db_instance.execute_query = AsyncMock(
+            return_value=(
+                [{"DATABASE_NAME": "PROD_DB"}, {"DATABASE_NAME": "TEMP_DB"}],
+                "test-id",
+            )
+        )
+
+        # Capture call_tool handler
+        call_tool_handler = None
+
+        def capture_call_tool():
+            def decorator(func):
+                nonlocal call_tool_handler
+                call_tool_handler = func
+                return func
+
+            return decorator
+
+        mock_server_instance.call_tool = capture_call_tool
+
+        with patch('src.mcp_snowflake_server.server.Server') as mock_server_class:
+            mock_server_class.return_value = mock_server_instance
+
+            connection_args = {"database": "test_db"}
+            exclude_patterns = {"databases": ["temp"]}
+
+            await main(
+                connection_args=connection_args,
+                exclude_patterns=exclude_patterns
+            )
+
+            # Test that exclusion patterns are applied
+            if call_tool_handler:
+                result = await call_tool_handler("list_databases", {})
+
+                # Parse the embedded resource to check filtering
+                resource_content = json.loads(result[1].resource.text)
+                database_names = [item["DATABASE_NAME"] for item in resource_content["data"]]
+
+                assert "PROD_DB" in database_names
+                assert "TEMP_DB" not in database_names  # Should be excluded

--- a/tests/test_write_detector.py
+++ b/tests/test_write_detector.py
@@ -1,0 +1,243 @@
+"""Unit tests for SQLWriteDetector class"""
+import sqlparse
+
+
+class TestSQLWriteDetector:
+    """Test cases for SQLWriteDetector"""
+
+    def test_init(self, write_detector):
+        """Test SQLWriteDetector initialization"""
+        assert isinstance(write_detector.dml_write_keywords, set)
+        assert isinstance(write_detector.ddl_keywords, set)
+        assert isinstance(write_detector.dcl_keywords, set)
+        assert isinstance(write_detector.write_keywords, set)
+
+        # Check that write_keywords contains all categories
+        assert write_detector.dml_write_keywords.issubset(write_detector.write_keywords)
+        assert write_detector.ddl_keywords.issubset(write_detector.write_keywords)
+        assert write_detector.dcl_keywords.issubset(write_detector.write_keywords)
+
+    def test_analyze_select_query(self, write_detector):
+        """Test analysis of SELECT queries (read-only)"""
+        queries = [
+            "SELECT * FROM users",
+            "SELECT name, email FROM users WHERE id = 1",
+            "SELECT COUNT(*) FROM orders",
+            "SELECT u.name, o.total FROM users u JOIN orders o ON u.id = o.user_id"
+        ]
+
+        for query in queries:
+            result = write_detector.analyze_query(query)
+            assert result["contains_write"] is False
+            assert len(result["write_operations"]) == 0
+            assert result["has_cte_write"] is False
+
+    def test_analyze_insert_query(self, write_detector):
+        """Test analysis of INSERT queries"""
+        queries = [
+            "INSERT INTO users (name, email) VALUES ('John', 'john@example.com')",
+            "INSERT INTO orders SELECT * FROM temp_orders",
+            "insert into products values (1, 'Product A')"  # lowercase
+        ]
+
+        for query in queries:
+            result = write_detector.analyze_query(query)
+            assert result["contains_write"] is True
+            assert "INSERT" in result["write_operations"]
+            assert result["has_cte_write"] is False
+
+    def test_analyze_update_query(self, write_detector):
+        """Test analysis of UPDATE queries"""
+        queries = [
+            "UPDATE users SET email = 'new@example.com' WHERE id = 1",
+            "UPDATE orders SET status = 'shipped' WHERE order_date < '2023-01-01'",
+            "update products set price = price * 1.1"  # lowercase
+        ]
+
+        for query in queries:
+            result = write_detector.analyze_query(query)
+            assert result["contains_write"] is True
+            assert "UPDATE" in result["write_operations"]
+            assert result["has_cte_write"] is False
+
+    def test_analyze_delete_query(self, write_detector):
+        """Test analysis of DELETE queries"""
+        queries = [
+            "DELETE FROM users WHERE id = 1",
+            "DELETE FROM orders WHERE status = 'cancelled'",
+            "delete from temp_table"  # lowercase
+        ]
+
+        for query in queries:
+            result = write_detector.analyze_query(query)
+            assert result["contains_write"] is True
+            assert "DELETE" in result["write_operations"]
+            assert result["has_cte_write"] is False
+
+    def test_analyze_ddl_queries(self, write_detector):
+        """Test analysis of DDL queries"""
+        queries_op_tuples = [
+            ("CREATE", "CREATE TABLE users (id INT, name VARCHAR(100))"),
+            ("ALTER", "ALTER TABLE users ADD COLUMN email VARCHAR(255)"),
+            ("DROP", "DROP TABLE temp_table"),
+            ("TRUNCATE", "TRUNCATE TABLE logs"),
+            ("CREATE", "create view user_summary as select * from users")
+        ]
+
+        for expected_op, query in queries_op_tuples:
+            result = write_detector.analyze_query(query)
+            assert result["contains_write"] is True
+            assert expected_op in result["write_operations"]
+            assert result["has_cte_write"] is False
+
+    def test_analyze_dcl_queries(self, write_detector):
+        """Test analysis of DCL queries"""
+        queries_op_tuples = [
+            ("GRANT", "GRANT SELECT ON users TO role_name"),
+            ("REVOKE", "REVOKE INSERT ON orders FROM user_name"),
+            ("GRANT", "grant all privileges on database test_db to role admin")
+        ]
+
+        for expected_op, query in queries_op_tuples:
+            result = write_detector.analyze_query(query)
+            assert result["contains_write"] is True
+            assert expected_op in result["write_operations"]
+            assert result["has_cte_write"] is False
+
+    def test_analyze_merge_upsert_queries(self, write_detector):
+        """Test analysis of MERGE and UPSERT queries"""
+        queries_op_tuples = [
+            ("MERGE", "MERGE INTO target USING source ON target.id = source.id WHEN MATCHED THEN UPDATE SET name = source.name"),
+            ("UPSERT", "UPSERT INTO users VALUES (1, 'John')"),
+            ("MERGE", "merge into products using staging_products on products.id = staging_products.id")
+        ]
+
+        for expected_op, query in queries_op_tuples:
+            result = write_detector.analyze_query(query)
+            assert result["contains_write"] is True
+            assert expected_op in result["write_operations"]
+            assert result["has_cte_write"] is False
+
+    def test_analyze_cte_with_select(self, write_detector):
+        """Test analysis of CTE with SELECT (read-only)"""
+        query = """
+        WITH user_stats AS (
+            SELECT user_id, COUNT(*) as order_count
+            FROM orders
+            GROUP BY user_id
+        )
+        SELECT u.name, us.order_count
+        FROM users u
+        JOIN user_stats us ON u.id = us.user_id
+        """
+
+        result = write_detector.analyze_query(query)
+        assert result["contains_write"] is False
+        assert len(result["write_operations"]) == 0
+        assert result["has_cte_write"] is False
+
+    def test_analyze_cte_with_write(self, write_detector):
+        """Test analysis of CTE with write operations"""
+        query = """
+        WITH updated_users AS (
+            UPDATE users SET last_login = CURRENT_TIMESTAMP
+            WHERE id IN (SELECT user_id FROM recent_activity)
+            RETURNING *
+        )
+        SELECT * FROM updated_users
+        """
+
+        result = write_detector.analyze_query(query)
+        assert result["contains_write"] is True
+        assert result["has_cte_write"] is True
+        assert "CTE_WRITE" in result["write_operations"]
+
+    def test_analyze_complex_query_with_multiple_operations(self, write_detector):
+        """Test analysis of complex queries with multiple write operations"""
+        query = """
+        INSERT INTO audit_log (action, table_name, timestamp)
+        VALUES ('UPDATE', 'users', CURRENT_TIMESTAMP);
+        
+        UPDATE users SET status = 'active' WHERE last_login > '2023-01-01';
+        """
+
+        result = write_detector.analyze_query(query)
+        assert result["contains_write"] is True
+        assert "INSERT" in result["write_operations"]
+        assert "UPDATE" in result["write_operations"]
+        assert result["has_cte_write"] is False
+
+    def test_analyze_empty_query(self, write_detector):
+        """Test analysis of empty or whitespace-only queries"""
+        queries = ["", "   ", "\n\t  \n"]
+
+        for query in queries:
+            result = write_detector.analyze_query(query)
+            assert result["contains_write"] is False
+            assert len(result["write_operations"]) == 0
+            assert result["has_cte_write"] is False
+
+    def test_analyze_comment_only_query(self, write_detector):
+        """Test analysis of queries with only comments"""
+        queries = [
+            "-- This is a comment",
+            "/* Multi-line comment */",
+            "-- SELECT * FROM users (commented out)"
+        ]
+
+        for query in queries:
+            result = write_detector.analyze_query(query)
+            assert result["contains_write"] is False
+            assert len(result["write_operations"]) == 0
+            assert result["has_cte_write"] is False
+
+    def test_has_cte_method(self, write_detector):
+        """Test the _has_cte method"""
+        # Query with CTE
+        query_with_cte = "WITH cte AS (SELECT * FROM users) SELECT * FROM cte"
+        parsed_with_cte = sqlparse.parse(query_with_cte)[0]
+        assert write_detector._has_cte(parsed_with_cte) is True
+
+        # Query without CTE
+        query_without_cte = "SELECT * FROM users"
+        parsed_without_cte = sqlparse.parse(query_without_cte)[0]
+        assert write_detector._has_cte(parsed_without_cte) is False
+
+    def test_find_write_operations_method(self, write_detector):
+        """Test the _find_write_operations method"""
+        # Test with INSERT query
+        insert_query = "INSERT INTO users VALUES (1, 'John')"
+        parsed_insert = sqlparse.parse(insert_query)[0]
+        operations = write_detector._find_write_operations(parsed_insert)
+        assert "INSERT" in operations
+
+        # Test with SELECT query
+        select_query = "SELECT * FROM users"
+        parsed_select = sqlparse.parse(select_query)[0]
+        operations = write_detector._find_write_operations(parsed_select)
+        assert len(operations) == 0
+
+    def test_analyze_cte_method(self, write_detector):
+        """Test the _analyze_cte method"""
+        # CTE with write operation
+        cte_write_query = """
+        WITH updated AS (
+            UPDATE users SET status = 'active'
+            RETURNING *
+        )
+        SELECT * FROM updated
+        """
+        parsed_cte_write = sqlparse.parse(cte_write_query)[0]
+        assert write_detector._analyze_cte(parsed_cte_write) is True
+
+        # CTE with only SELECT
+        cte_select_query = """
+        WITH user_stats AS (
+            SELECT user_id, COUNT(*) as count
+            FROM orders
+            GROUP BY user_id
+        )
+        SELECT * FROM user_stats
+        """
+        parsed_cte_select = sqlparse.parse(cte_select_query)[0]
+        assert write_detector._analyze_cte(parsed_cte_select) is False


### PR DESCRIPTION
## Directory structure:

```
tests/
├── __init__.py                 # Test package initialization
├── conftest.py                 # Pytest configuration and shared fixtures
├── test_write_detector.py      # Unit tests for SQLWriteDetector
├── test_db_client.py           # Unit tests for SnowflakeDB client
├── test_server_handlers.py     # Unit tests for server tool handlers
└── test_server_integration.py  # Integration tests for main server
```

## Test Categories

### Unit Tests
- **SQLWriteDetector Tests** (`test_write_detector.py`): Tests SQL query analysis and write operation detection
- **SnowflakeDB Tests** (`test_db_client.py`): Tests database client functionality, connection management, and query execution
- **Server Handler Tests** (`test_server_handlers.py`): Tests individual tool handlers and utility functions

### Integration Tests
- **Server Integration Tests** (`test_server_integration.py`): Tests complete server functionality, configuration loading, and tool integration
