### PR TITLE
DATAOPS-13977: Add two new tools to MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ The server exposes the following tools:
   - `table_name` (string): Fully qualified table name (`database.schema.table`)  
   **Returns:** Array of column definitions with names, types, nullability, defaults, and comments
 
+- **`get_database_info`**
+  Get detailed info for a specific database.
+  **Input:**
+  - `database` (string): Name of the database
+  **Returns:** Dictionary with keys such as comment, created_on, etc for the specific database
+
+- **`get_database_ddl`**
+  Get detailed info for all databases or some databases that match a given pattern. Detailed information includes column names, column types, constraints, and metadata
+  **Input:**
+  - `database` (string): Name of the database substring / pattern
+  **Returns:** Array of dictionaries
+
 #### Analysis Tools
 
 - **`append_insight`**  

--- a/src/mcp_snowflake_server/processor.py
+++ b/src/mcp_snowflake_server/processor.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime, UTC
 
 logger = logging.getLogger('mcp_snowflake_dataops_server')
 logger.setLevel(logging.ERROR)

--- a/src/mcp_snowflake_server/processor.py
+++ b/src/mcp_snowflake_server/processor.py
@@ -1,0 +1,149 @@
+import logging
+from datetime import datetime, UTC
+
+logger = logging.getLogger('mcp_snowflake_dataops_server')
+logger.setLevel(logging.ERROR)
+
+
+class Processor:
+
+    def __init__(self, db):
+        self.db = db
+
+    async def _retrieve_table_metadata(self, db_name):
+        tables_query = f"""
+            SELECT 
+                TABLE_SCHEMA,
+                TABLE_NAME,
+                TABLE_TYPE,
+                TABLE_OWNER,
+                COMMENT as TABLE_COMMENT
+            FROM {db_name}.INFORMATION_SCHEMA.TABLES
+            WHERE TABLE_SCHEMA != 'INFORMATION_SCHEMA'
+        """
+        logger.debug(f"Executing tables query: {tables_query}")
+        tables, _ = await self.db.execute_query(tables_query)
+        logger.info(f"Retrieved {len(tables)} columns")
+        return tables
+
+    async def _retrieve_column_metadata(self, db_name):
+        columns_query = f"""
+            SELECT 
+                TABLE_SCHEMA,
+                TABLE_NAME,
+                COLUMN_NAME,
+                DATA_TYPE,
+                COMMENT as COLUMN_COMMENT,
+                ORDINAL_POSITION
+            FROM {db_name}.INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_SCHEMA != 'INFORMATION_SCHEMA'
+            ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION
+        """
+        logger.debug(f"Executing columns query: {columns_query}")
+        columns, _ = await self.db.execute_query(columns_query)
+        logger.info(f"Retrieved {len(columns)} columns")
+        return columns
+
+    async def _retrieve_constraints(self, db_name):
+        constraints_query = f"""
+            SELECT
+                TABLE_SCHEMA,
+                TABLE_NAME,
+                CONSTRAINT_NAME,
+                CONSTRAINT_TYPE,
+                ENFORCED as IS_ENFORCED,
+                INITIALLY_DEFERRED as IS_DEFERRABLE,
+                COMMENT as CONSTRAINT_COMMENT
+            FROM {db_name}.INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+            WHERE TABLE_SCHEMA != 'INFORMATION_SCHEMA'
+            ORDER BY TABLE_SCHEMA, TABLE_NAME, CONSTRAINT_NAME
+        """
+        logger.debug(f"Executing constraints query for {db_name}: {constraints_query}")
+        constraints, _ = await self.db.execute_query(constraints_query)
+        logger.info(f"Retrieved {len(constraints)} constraints from {db_name}")
+        return constraints
+
+    @staticmethod
+    def _process_tables(tables, schemas):
+        for table in tables:
+            schema_name = table['TABLE_SCHEMA']
+            table_name = table['TABLE_NAME']
+
+            # Initialize schema if needed
+            if schema_name not in schemas:
+                schemas[schema_name] = {"tables": {}}
+
+            # Create table entry
+            table_info = {
+                "type": table['TABLE_TYPE'],
+                "owner": table['TABLE_OWNER'],
+                "columns": []
+            }
+
+            if table['TABLE_COMMENT']:
+                table_info["comment"] = table['TABLE_COMMENT']
+
+            schemas[schema_name]["tables"][table_name] = table_info
+
+    @staticmethod
+    def _process_columns(columns, schema):
+        for col in columns:
+            schema_name = col['TABLE_SCHEMA']
+            table_name = col['TABLE_NAME']
+
+            col_info = {
+                "name": col['COLUMN_NAME'],
+                "type": col['DATA_TYPE']
+            }
+            if col['COLUMN_COMMENT']:
+                col_info["comment"] = col['COLUMN_COMMENT']
+
+            schema[schema_name]["tables"][table_name]["columns"].append(col_info)
+
+    @staticmethod
+    def _process_constraints(constraints, schema):
+        for constraint in constraints:
+            schema_name = constraint['TABLE_SCHEMA']
+            table_name = constraint['TABLE_NAME']
+
+            if not schema[schema_name]["tables"][table_name].get("constraints"):
+                schema[schema_name]["tables"][table_name]["constraints"] = []
+
+            constraint_info = {
+                "name": constraint['CONSTRAINT_NAME'],
+                "type": constraint['CONSTRAINT_TYPE']
+            }
+            if constraint['CONSTRAINT_COMMENT']:
+                constraint_info["comment"] = constraint['CONSTRAINT_COMMENT']
+            if constraint['IS_ENFORCED'] is not None:
+                constraint_info["is_enforced"] = constraint['IS_ENFORCED']
+            if constraint['IS_DEFERRABLE'] is not None:
+                constraint_info["is_deferrable"] = constraint['IS_DEFERRABLE']
+
+            schema[schema_name]["tables"][table_name]["constraints"].append(constraint_info)
+
+    async def process_database_structure(self, db_name, database_info):
+        """Process a database using its Information Schema"""
+        logger.info(f"Starting to process database: {db_name}")
+
+        # Initialize database structure
+        schema = {}
+        database_structure = {
+            "metadata": {
+                "kind": database_info.get('kind', 'IMPORTED DATABASE'),
+                "owner": database_info.get('owner', ''),
+                "comment": database_info.get('comment', ''),
+            },
+            "schemas": schema
+        }
+
+        # Get tables metadata and process it
+        self._process_tables(await self._retrieve_table_metadata(db_name), schema)
+
+        # Get columns data and process it
+        self._process_columns(await self._retrieve_column_metadata(db_name), schema)
+
+        # Get constraints data and process it
+        self._process_constraints(await self._retrieve_constraints(db_name), schema)
+
+        return database_structure

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,0 +1,577 @@
+"""Unit tests for Processor class"""
+
+import pytest
+from unittest.mock import Mock, AsyncMock
+from src.mcp_snowflake_server.processor import Processor
+
+
+class TestProcessor:
+    """Test cases for Processor class"""
+
+    def test_init(self, mock_db_client):
+        """Test Processor initialization"""
+        processor = Processor(mock_db_client)
+        assert processor.db == mock_db_client
+
+    @pytest.mark.asyncio
+    async def test_retrieve_table_metadata(self, mock_db_client):
+        """Test _retrieve_table_metadata method"""
+        # Setup mock return data
+        expected_tables = [
+            {
+                'TABLE_SCHEMA': 'PUBLIC',
+                'TABLE_NAME': 'USERS',
+                'TABLE_TYPE': 'BASE TABLE',
+                'TABLE_OWNER': 'ADMIN',
+                'TABLE_COMMENT': 'User information table'
+            },
+            {
+                'TABLE_SCHEMA': 'PUBLIC',
+                'TABLE_NAME': 'ORDERS',
+                'TABLE_TYPE': 'BASE TABLE',
+                'TABLE_OWNER': 'ADMIN',
+                'TABLE_COMMENT': None
+            }
+        ]
+        mock_db_client.execute_query.return_value = (expected_tables, "test-data-id")
+
+        processor = Processor(mock_db_client)
+        result = await processor._retrieve_table_metadata("TEST_DB")
+
+        assert result == expected_tables
+        mock_db_client.execute_query.assert_called_once()
+        
+        # Verify the SQL query structure
+        call_args = mock_db_client.execute_query.call_args[0][0]
+        assert "TEST_DB.INFORMATION_SCHEMA.TABLES" in call_args
+        assert "TABLE_SCHEMA != 'INFORMATION_SCHEMA'" in call_args
+
+    @pytest.mark.asyncio
+    async def test_retrieve_column_metadata(self, mock_db_client):
+        """Test _retrieve_column_metadata method"""
+        # Setup mock return data
+        expected_columns = [
+            {
+                'TABLE_SCHEMA': 'PUBLIC',
+                'TABLE_NAME': 'USERS',
+                'COLUMN_NAME': 'ID',
+                'DATA_TYPE': 'NUMBER',
+                'COLUMN_COMMENT': 'Primary key',
+                'ORDINAL_POSITION': 1
+            },
+            {
+                'TABLE_SCHEMA': 'PUBLIC',
+                'TABLE_NAME': 'USERS',
+                'COLUMN_NAME': 'NAME',
+                'DATA_TYPE': 'VARCHAR',
+                'COLUMN_COMMENT': 'User name',
+                'ORDINAL_POSITION': 2
+            }
+        ]
+        mock_db_client.execute_query.return_value = (expected_columns, "test-data-id")
+
+        processor = Processor(mock_db_client)
+        result = await processor._retrieve_column_metadata("TEST_DB")
+
+        assert result == expected_columns
+        mock_db_client.execute_query.assert_called_once()
+        
+        # Verify the SQL query structure
+        call_args = mock_db_client.execute_query.call_args[0][0]
+        assert "TEST_DB.INFORMATION_SCHEMA.COLUMNS" in call_args
+        assert "ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION" in call_args
+
+    @pytest.mark.asyncio
+    async def test_retrieve_constraints(self, mock_db_client):
+        """Test _retrieve_constraints method"""
+        # Setup mock return data
+        expected_constraints = [
+            {
+                'TABLE_SCHEMA': 'PUBLIC',
+                'TABLE_NAME': 'USERS',
+                'CONSTRAINT_NAME': 'PK_USERS',
+                'CONSTRAINT_TYPE': 'PRIMARY KEY',
+                'IS_ENFORCED': 'YES',
+                'IS_DEFERRABLE': 'NO',
+                'CONSTRAINT_COMMENT': 'Primary key constraint'
+            }
+        ]
+        mock_db_client.execute_query.return_value = (expected_constraints, "test-data-id")
+
+        processor = Processor(mock_db_client)
+        result = await processor._retrieve_constraints("TEST_DB")
+
+        assert result == expected_constraints
+        mock_db_client.execute_query.assert_called_once()
+        
+        # Verify the SQL query structure
+        call_args = mock_db_client.execute_query.call_args[0][0]
+        assert "TEST_DB.INFORMATION_SCHEMA.TABLE_CONSTRAINTS" in call_args
+        assert "ORDER BY TABLE_SCHEMA, TABLE_NAME, CONSTRAINT_NAME" in call_args
+
+
+class TestProcessorStaticMethods:
+    """Test cases for Processor static methods"""
+
+    def test_process_tables_empty_input(self):
+        """Test _process_tables with empty input"""
+        schemas = {}
+        tables = []
+        
+        Processor._process_tables(tables, schemas)
+        
+        assert schemas == {}
+
+    def test_process_tables_single_table(self):
+        """Test _process_tables with single table"""
+        schemas = {}
+        tables = [
+            {
+                'TABLE_SCHEMA': 'PUBLIC',
+                'TABLE_NAME': 'USERS',
+                'TABLE_TYPE': 'BASE TABLE',
+                'TABLE_OWNER': 'ADMIN',
+                'TABLE_COMMENT': 'User information table'
+            }
+        ]
+        
+        Processor._process_tables(tables, schemas)
+        
+        assert 'PUBLIC' in schemas
+        assert 'tables' in schemas['PUBLIC']
+        assert 'USERS' in schemas['PUBLIC']['tables']
+        
+        user_table = schemas['PUBLIC']['tables']['USERS']
+        assert user_table['type'] == 'BASE TABLE'
+        assert user_table['owner'] == 'ADMIN'
+        assert user_table['comment'] == 'User information table'
+        assert user_table['columns'] == []
+
+    def test_process_tables_multiple_tables_multiple_schemas(self):
+        """Test _process_tables with multiple tables across multiple schemas"""
+        schemas = {}
+        tables = [
+            {
+                'TABLE_SCHEMA': 'PUBLIC',
+                'TABLE_NAME': 'USERS',
+                'TABLE_TYPE': 'BASE TABLE',
+                'TABLE_OWNER': 'ADMIN',
+                'TABLE_COMMENT': 'User information table'
+            },
+            {
+                'TABLE_SCHEMA': 'PUBLIC',
+                'TABLE_NAME': 'ORDERS',
+                'TABLE_TYPE': 'BASE TABLE',
+                'TABLE_OWNER': 'ADMIN',
+                'TABLE_COMMENT': None
+            },
+            {
+                'TABLE_SCHEMA': 'ANALYTICS',
+                'TABLE_NAME': 'REPORTS',
+                'TABLE_TYPE': 'VIEW',
+                'TABLE_OWNER': 'ANALYST',
+                'TABLE_COMMENT': 'Analytics reports'
+            }
+        ]
+        
+        Processor._process_tables(tables, schemas)
+        
+        # Check PUBLIC schema
+        assert 'PUBLIC' in schemas
+        assert 'USERS' in schemas['PUBLIC']['tables']
+        assert 'ORDERS' in schemas['PUBLIC']['tables']
+        
+        # Check ANALYTICS schema
+        assert 'ANALYTICS' in schemas
+        assert 'REPORTS' in schemas['ANALYTICS']['tables']
+        
+        # Verify table without comment
+        orders_table = schemas['PUBLIC']['tables']['ORDERS']
+        assert 'comment' not in orders_table
+        
+        # Verify view type
+        reports_table = schemas['ANALYTICS']['tables']['REPORTS']
+        assert reports_table['type'] == 'VIEW'
+
+    def test_process_tables_existing_schema(self):
+        """Test _process_tables with existing schema"""
+        schemas = {
+            'PUBLIC': {
+                'tables': {
+                    'EXISTING_TABLE': {
+                        'type': 'BASE TABLE',
+                        'owner': 'USER',
+                        'columns': []
+                    }
+                }
+            }
+        }
+        tables = [
+            {
+                'TABLE_SCHEMA': 'PUBLIC',
+                'TABLE_NAME': 'NEW_TABLE',
+                'TABLE_TYPE': 'VIEW',
+                'TABLE_OWNER': 'ADMIN',
+                'TABLE_COMMENT': 'New table'
+            }
+        ]
+        
+        Processor._process_tables(tables, schemas)
+        
+        # Verify existing table is preserved
+        assert 'EXISTING_TABLE' in schemas['PUBLIC']['tables']
+        # Verify new table is added
+        assert 'NEW_TABLE' in schemas['PUBLIC']['tables']
+        assert schemas['PUBLIC']['tables']['NEW_TABLE']['type'] == 'VIEW'
+
+    def test_process_columns_empty_input(self):
+        """Test _process_columns with empty input"""
+        schema = {
+            'PUBLIC': {
+                'tables': {
+                    'USERS': {
+                        'type': 'BASE TABLE',
+                        'owner': 'ADMIN',
+                        'columns': []
+                    }
+                }
+            }
+        }
+        columns = []
+        
+        Processor._process_columns(columns, schema)
+        
+        # Schema should remain unchanged
+        assert schema['PUBLIC']['tables']['USERS']['columns'] == []
+
+    def test_process_columns_single_column(self):
+        """Test _process_columns with single column"""
+        schema = {
+            'PUBLIC': {
+                'tables': {
+                    'USERS': {
+                        'type': 'BASE TABLE',
+                        'owner': 'ADMIN',
+                        'columns': []
+                    }
+                }
+            }
+        }
+        columns = [
+            {
+                'TABLE_SCHEMA': 'PUBLIC',
+                'TABLE_NAME': 'USERS',
+                'COLUMN_NAME': 'ID',
+                'DATA_TYPE': 'NUMBER',
+                'COLUMN_COMMENT': 'Primary key'
+            }
+        ]
+        
+        Processor._process_columns(columns, schema)
+        
+        user_columns = schema['PUBLIC']['tables']['USERS']['columns']
+        assert len(user_columns) == 1
+        assert user_columns[0]['name'] == 'ID'
+        assert user_columns[0]['type'] == 'NUMBER'
+        assert user_columns[0]['comment'] == 'Primary key'
+
+    def test_process_columns_multiple_columns(self):
+        """Test _process_columns with multiple columns"""
+        schema = {
+            'PUBLIC': {
+                'tables': {
+                    'USERS': {
+                        'type': 'BASE TABLE',
+                        'owner': 'ADMIN',
+                        'columns': []
+                    }
+                }
+            }
+        }
+        columns = [
+            {
+                'TABLE_SCHEMA': 'PUBLIC',
+                'TABLE_NAME': 'USERS',
+                'COLUMN_NAME': 'ID',
+                'DATA_TYPE': 'NUMBER',
+                'COLUMN_COMMENT': 'Primary key'
+            },
+            {
+                'TABLE_SCHEMA': 'PUBLIC',
+                'TABLE_NAME': 'USERS',
+                'COLUMN_NAME': 'NAME',
+                'DATA_TYPE': 'VARCHAR',
+                'COLUMN_COMMENT': None
+            }
+        ]
+        
+        Processor._process_columns(columns, schema)
+        
+        user_columns = schema['PUBLIC']['tables']['USERS']['columns']
+        assert len(user_columns) == 2
+        
+        # Check first column
+        assert user_columns[0]['name'] == 'ID'
+        assert user_columns[0]['type'] == 'NUMBER'
+        assert user_columns[0]['comment'] == 'Primary key'
+        
+        # Check second column (no comment)
+        assert user_columns[1]['name'] == 'NAME'
+        assert user_columns[1]['type'] == 'VARCHAR'
+        assert 'comment' not in user_columns[1]
+
+    def test_process_constraints_empty_input(self):
+        """Test _process_constraints with empty input"""
+        schema = {
+            'PUBLIC': {
+                'tables': {
+                    'USERS': {
+                        'type': 'BASE TABLE',
+                        'owner': 'ADMIN',
+                        'columns': []
+                    }
+                }
+            }
+        }
+        constraints = []
+        
+        Processor._process_constraints(constraints, schema)
+        
+        # Schema should remain unchanged, no constraints key should be added
+        assert 'constraints' not in schema['PUBLIC']['tables']['USERS']
+
+    def test_process_constraints_single_constraint(self):
+        """Test _process_constraints with single constraint"""
+        schema = {
+            'PUBLIC': {
+                'tables': {
+                    'USERS': {
+                        'type': 'BASE TABLE',
+                        'owner': 'ADMIN',
+                        'columns': []
+                    }
+                }
+            }
+        }
+        constraints = [
+            {
+                'TABLE_SCHEMA': 'PUBLIC',
+                'TABLE_NAME': 'USERS',
+                'CONSTRAINT_NAME': 'PK_USERS',
+                'CONSTRAINT_TYPE': 'PRIMARY KEY',
+                'CONSTRAINT_COMMENT': 'Primary key constraint',
+                'IS_ENFORCED': 'YES',
+                'IS_DEFERRABLE': 'NO'
+            }
+        ]
+        
+        Processor._process_constraints(constraints, schema)
+        
+        user_constraints = schema['PUBLIC']['tables']['USERS']['constraints']
+        assert len(user_constraints) == 1
+        assert user_constraints[0]['name'] == 'PK_USERS'
+        assert user_constraints[0]['type'] == 'PRIMARY KEY'
+        assert user_constraints[0]['comment'] == 'Primary key constraint'
+        assert user_constraints[0]['is_enforced'] == 'YES'
+        assert user_constraints[0]['is_deferrable'] == 'NO'
+
+    def test_process_constraints_multiple_constraints(self):
+        """Test _process_constraints with multiple constraints"""
+        schema = {
+            'PUBLIC': {
+                'tables': {
+                    'USERS': {
+                        'type': 'BASE TABLE',
+                        'owner': 'ADMIN',
+                        'columns': []
+                    }
+                }
+            }
+        }
+        constraints = [
+            {
+                'TABLE_SCHEMA': 'PUBLIC',
+                'TABLE_NAME': 'USERS',
+                'CONSTRAINT_NAME': 'PK_USERS',
+                'CONSTRAINT_TYPE': 'PRIMARY KEY',
+                'CONSTRAINT_COMMENT': 'Primary key constraint',
+                'IS_ENFORCED': 'YES',
+                'IS_DEFERRABLE': 'NO'
+            },
+            {
+                'TABLE_SCHEMA': 'PUBLIC',
+                'TABLE_NAME': 'USERS',
+                'CONSTRAINT_NAME': 'UK_USERS_EMAIL',
+                'CONSTRAINT_TYPE': 'UNIQUE',
+                'CONSTRAINT_COMMENT': None,
+                'IS_ENFORCED': None,
+                'IS_DEFERRABLE': None
+            }
+        ]
+        
+        Processor._process_constraints(constraints, schema)
+        
+        user_constraints = schema['PUBLIC']['tables']['USERS']['constraints']
+        assert len(user_constraints) == 2
+        
+        # Check first constraint
+        assert user_constraints[0]['name'] == 'PK_USERS'
+        assert user_constraints[0]['type'] == 'PRIMARY KEY'
+        assert user_constraints[0]['comment'] == 'Primary key constraint'
+        
+        # Check second constraint (with None values)
+        assert user_constraints[1]['name'] == 'UK_USERS_EMAIL'
+        assert user_constraints[1]['type'] == 'UNIQUE'
+        assert 'comment' not in user_constraints[1]
+        assert 'is_enforced' not in user_constraints[1]
+        assert 'is_deferrable' not in user_constraints[1]
+
+    def test_process_constraints_existing_constraints(self):
+        """Test _process_constraints with existing constraints"""
+        schema = {
+            'PUBLIC': {
+                'tables': {
+                    'USERS': {
+                        'type': 'BASE TABLE',
+                        'owner': 'ADMIN',
+                        'columns': [],
+                        'constraints': [
+                            {
+                                'name': 'EXISTING_CONSTRAINT',
+                                'type': 'CHECK'
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        constraints = [
+            {
+                'TABLE_SCHEMA': 'PUBLIC',
+                'TABLE_NAME': 'USERS',
+                'CONSTRAINT_NAME': 'PK_USERS',
+                'CONSTRAINT_TYPE': 'PRIMARY KEY',
+                'CONSTRAINT_COMMENT': 'Primary key constraint',
+                'IS_ENFORCED': 'YES',
+                'IS_DEFERRABLE': 'NO'
+            }
+        ]
+        
+        Processor._process_constraints(constraints, schema)
+        
+        user_constraints = schema['PUBLIC']['tables']['USERS']['constraints']
+        assert len(user_constraints) == 2
+        
+        # Verify existing constraint is preserved
+        assert user_constraints[0]['name'] == 'EXISTING_CONSTRAINT'
+        # Verify new constraint is added
+        assert user_constraints[1]['name'] == 'PK_USERS'
+
+    @pytest.mark.asyncio
+    async def test_process_database_structure_complete_flow(self, mock_db_client):
+        """Test complete process_database_structure method"""
+        # Setup mock data for all three queries
+        mock_tables = [
+            {
+                'TABLE_SCHEMA': 'PUBLIC',
+                'TABLE_NAME': 'USERS',
+                'TABLE_TYPE': 'BASE TABLE',
+                'TABLE_OWNER': 'ADMIN',
+                'TABLE_COMMENT': 'User information table'
+            }
+        ]
+        
+        mock_columns = [
+            {
+                'TABLE_SCHEMA': 'PUBLIC',
+                'TABLE_NAME': 'USERS',
+                'COLUMN_NAME': 'ID',
+                'DATA_TYPE': 'NUMBER',
+                'COLUMN_COMMENT': 'Primary key',
+                'ORDINAL_POSITION': 1
+            }
+        ]
+        
+        mock_constraints = [
+            {
+                'TABLE_SCHEMA': 'PUBLIC',
+                'TABLE_NAME': 'USERS',
+                'CONSTRAINT_NAME': 'PK_USERS',
+                'CONSTRAINT_TYPE': 'PRIMARY KEY',
+                'CONSTRAINT_COMMENT': 'Primary key constraint',
+                'IS_ENFORCED': 'YES',
+                'IS_DEFERRABLE': 'NO'
+            }
+        ]
+        
+        # Setup mock to return different data for each call
+        mock_db_client.execute_query.side_effect = [
+            (mock_tables, "tables-data-id"),
+            (mock_columns, "columns-data-id"),
+            (mock_constraints, "constraints-data-id")
+        ]
+        
+        database_info = {
+            'kind': 'STANDARD',
+            'owner': 'ADMIN',
+            'comment': 'Test database'
+        }
+        
+        processor = Processor(mock_db_client)
+        result = await processor.process_database_structure("TEST_DB", database_info)
+        
+        # Verify structure
+        assert 'metadata' in result
+        assert 'schemas' in result
+        
+        # Verify metadata
+        metadata = result['metadata']
+        assert metadata['kind'] == 'STANDARD'
+        assert metadata['owner'] == 'ADMIN'
+        assert metadata['comment'] == 'Test database'
+        
+        # Verify schema structure
+        schemas = result['schemas']
+        assert 'PUBLIC' in schemas
+        assert 'USERS' in schemas['PUBLIC']['tables']
+        
+        # Verify table structure
+        users_table = schemas['PUBLIC']['tables']['USERS']
+        assert users_table['type'] == 'BASE TABLE'
+        assert users_table['owner'] == 'ADMIN'
+        assert users_table['comment'] == 'User information table'
+        
+        # Verify columns
+        assert len(users_table['columns']) == 1
+        assert users_table['columns'][0]['name'] == 'ID'
+        assert users_table['columns'][0]['type'] == 'NUMBER'
+        
+        # Verify constraints
+        assert len(users_table['constraints']) == 1
+        assert users_table['constraints'][0]['name'] == 'PK_USERS'
+        assert users_table['constraints'][0]['type'] == 'PRIMARY KEY'
+        
+        # Verify all three queries were called
+        assert mock_db_client.execute_query.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_process_database_structure_default_metadata(self, mock_db_client):
+        """Test process_database_structure with default metadata values"""
+        # Setup minimal mock data
+        mock_db_client.execute_query.side_effect = [
+            ([], "tables-data-id"),
+            ([], "columns-data-id"),
+            ([], "constraints-data-id")
+        ]
+        
+        # Empty database info
+        database_info = {}
+        
+        processor = Processor(mock_db_client)
+        result = await processor.process_database_structure("TEST_DB", database_info)
+        
+        # Verify default metadata values
+        metadata = result['metadata']
+        assert metadata['kind'] == 'IMPORTED DATABASE'
+        assert metadata['owner'] == ''
+        assert metadata['comment'] == ''

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -298,7 +298,7 @@ class TestServerHandlers:
         assert resource_content["data"] == sample_database_info
 
         # Verify the query was called with uppercase database name
-        mock_db_client.execute_query.assert_called_once_with("SHOW DATABASES LIKE 'TEST_DATABASE'")
+        mock_db_client.execute_query.assert_called_once_with("SHOW DATABASES LIKE '%test_database%'")
 
     @pytest.mark.asyncio
     async def test_handle_get_database_info_missing_database(self, mock_db_client):

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -146,7 +146,7 @@ class TestServerHandlers:
         mock_db_client.execute_query.return_value = (query_results, "test-data-id")
         arguments = {"query": "SELECT * FROM users"}
 
-        result = await handle_read_query(arguments, mock_db_client, write_detector)
+        result = await handle_read_query(arguments, mock_db_client, None, False, write_detector, None)
 
         assert len(result) == 2
         assert isinstance(result[0], types.TextContent)
@@ -158,7 +158,7 @@ class TestServerHandlers:
         arguments = {"query": "INSERT INTO users VALUES (1, 'John')"}
 
         with pytest.raises(ValueError, match="Calls to read_query should not contain write operations"):
-            await handle_read_query(arguments, mock_db_client, write_detector)
+            await handle_read_query(arguments, mock_db_client, None, False, write_detector, None)
 
     @pytest.mark.asyncio
     async def test_handle_read_query_missing_query(self, mock_db_client, write_detector):
@@ -171,7 +171,7 @@ class TestServerHandlers:
         """Test successful insight appending"""
         arguments = {"insight": "Users table has grown by 20%"}
 
-        result = await handle_append_insight(arguments, mock_db_client, None, None, mock_server)
+        result = await handle_append_insight(arguments, mock_db_client, mock_server, None, None, None)
 
         assert len(result) == 1
         assert isinstance(result[0], types.TextContent)

--- a/tests/test_server_integration.py
+++ b/tests/test_server_integration.py
@@ -213,7 +213,7 @@ class TestServerIntegration:
                 tool_names = {tool.name for tool in tools}
 
             # Should include read-only tools
-            assert tool_names == {'list_databases', 'list_schemas', 'list_tables',
+            assert tool_names == {'list_databases', 'list_schemas', 'list_tables', 'get_database_ddl',
                                   'read_query', 'append_insight', 'get_database_info'}
 
 

--- a/tests/test_server_integration.py
+++ b/tests/test_server_integration.py
@@ -213,7 +213,8 @@ class TestServerIntegration:
                 tool_names = {tool.name for tool in tools}
 
             # Should include read-only tools
-            assert tool_names == {'list_databases', 'list_schemas', 'list_tables', 'read_query', 'append_insight'}
+            assert tool_names == {'list_databases', 'list_schemas', 'list_tables',
+                                  'read_query', 'append_insight', 'get_database_info'}
 
 
 class TestServerResourceHandlers:


### PR DESCRIPTION
Two new tools have been added:
* Added `get_database_info` that retrieves information about a database
* Added `get_database_ddl` that can work of multiple databases and return a list of databases, tables for each database, columns for each table (name and type). It will also list out any constraints and includes metadata.

Sample output from `get_database_ddl` in YAML format:

```yaml
databases:
  ALI_LAKHIA_TESTS_MCP_SERVER:
    metadata:
      comment: ''
      kind: STANDARD
      owner: ACCOUNTADMIN
    schemas:
      PUBLIC:
        tables:
          USERS:
            columns:
            - name: ID
              type: NUMBER
            - name: NAME
              type: TEXT
            - name: PREFERENCES
              type: VARIANT
            - name: CREATED_AT
              type: TIMESTAMP_NTZ
            constraints:
            - is_deferrable: 'YES'
              is_enforced: 'NO'
              name: NAME_UNIQUE
              type: UNIQUE
            owner: ACCOUNTADMIN
            type: BASE TABLE
``` 

Sample output for `get_database_info` is:

```yaml
data_id: 3d724dee-f086-45a7-bacd-f449bfa5ca23
database: ALI_LAKHIA_TESTS_MCP_SERVER
data:
- created_on: 2025-07-16 12:45:08.875000-07:00
  name: ALI_LAKHIA_TESTS_MCP_SERVER
  is_default: Y
  is_current: Y
  origin: ''
  owner: ACCOUNTADMIN
  comment: ''
  options: ''
  retention_time: '3'
  kind: STANDARD
  owner_role_type: ROLE
  object_visibility: null```