### PR TITLE
DATAOPS-14087: Snowflake MCP Server Fails to Start

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,9 +27,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+        uses: astral-sh/setup-uv@v6
 
       - name: Build release distributions
         run: |
@@ -61,9 +59,7 @@ jobs:
           path: dist/
 
       - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+        uses: astral-sh/setup-uv@v6
 
       - name: Publish release distributions to private repository
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,13 @@ readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [
     "mcp>=1.0.0",
-    "snowflake-connector-python[pandas]>=3.12.0,<3.14.0",
+    "snowflake-connector-python[pandas]==3.17.3",
     "pandas>=2.2.3",
     "python-dotenv>=1.0.1",
     "sqlparse>=0.5.3",
     "snowflake-snowpark-python>=1.26.0",
+    "cryptography>=45.0.7",
+    "pyopenssl==25.3.0",
 ]
 
 [build-system]


### PR DESCRIPTION
Our ⁠cryptography library version expects a newer OpenSSL version than what's installed. I went ahead and upgraded both along with the snowflake connector library.